### PR TITLE
Add Generation of GeneratedCodeAttribute on partial class

### DIFF
--- a/src/Amadevus.RecordGenerator.Generators/GeneratedCodeAttributeGenerator.cs
+++ b/src/Amadevus.RecordGenerator.Generators/GeneratedCodeAttributeGenerator.cs
@@ -1,0 +1,81 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Amadevus.RecordGenerator.Generators
+{
+    public static class GeneratedCodeAttributeGeneratorExtensions
+    {
+        public static TypeDeclarationSyntax WithGeneratedCodeAttribute(
+            this TypeDeclarationSyntax typeSyntax)
+        {
+            return new GeneratedCodeAttributeGenerator(typeSyntax)
+                .GetWithGeneratedCodeAttribute();
+        }
+    }
+
+    internal sealed class GeneratedCodeAttributeGenerator
+    {
+        private readonly TypeDeclarationSyntax typeSyntax;
+
+        public GeneratedCodeAttributeGenerator(
+            TypeDeclarationSyntax typeSyntax)
+        {
+            this.typeSyntax = typeSyntax;
+        }
+
+        public TypeDeclarationSyntax GetWithGeneratedCodeAttribute()
+        {
+            return typeSyntax.WithAttributeLists(
+                SingletonList(
+                    AttributeList(
+                        SingletonSeparatedList(
+                            Attribute(GenerateQualifiedName())
+                            .WithArgumentList(GenerateAttributeArgumentList())))));
+        } 
+
+        private AttributeArgumentListSyntax GenerateAttributeArgumentList()
+        {
+            var toolName = Names.ToolName;
+            var toolVersion = GetToolVersion();
+
+            return AttributeArgumentList(
+                SeparatedList<AttributeArgumentSyntax>(
+                    new SyntaxNodeOrToken[]{
+                        AttributeArgument(
+                            LiteralExpression(
+                                SyntaxKind.StringLiteralExpression,
+                                Literal(toolName))),
+                        Token(SyntaxKind.CommaToken),
+                        AttributeArgument(
+                            LiteralExpression(
+                                SyntaxKind.StringLiteralExpression,
+                                Literal(toolVersion)))}));
+        }
+
+        private QualifiedNameSyntax GenerateQualifiedName()
+        {
+            var namespaceAndIdentifier = Names.GeneratedCodeAttribute.Split('.')
+                .Select(n => IdentifierName(n)).ToList();
+
+            var attributeName = QualifiedName(
+                namespaceAndIdentifier.First(),
+                namespaceAndIdentifier.Skip(1).First());
+
+            foreach (var identifier in namespaceAndIdentifier.Skip(2))
+            {
+                attributeName = QualifiedName(attributeName, identifier);
+            }
+
+            return attributeName; 
+        }
+
+        private string GetToolVersion() => GetType().GetTypeInfo().Assembly.GetName().Version.ToString();
+    }
+}

--- a/src/Amadevus.RecordGenerator.Generators/Names.cs
+++ b/src/Amadevus.RecordGenerator.Generators/Names.cs
@@ -14,5 +14,8 @@
         public const string ToBuilder = "ToBuilder";
         public const string ToImmutable = "ToImmutable";
         public const string Validate = "Validate";
+
+        public const string ToolName = "Amadevus.RecordGenerator";
+        public const string GeneratedCodeAttribute = "System.CodeDom.Compiler.GeneratedCodeAttribute";
     }
 }

--- a/src/Amadevus.RecordGenerator.Generators/PartialGeneratorBase.cs
+++ b/src/Amadevus.RecordGenerator.Generators/PartialGeneratorBase.cs
@@ -34,7 +34,7 @@ namespace Amadevus.RecordGenerator.Generators
                     GenerateModifiers())
                 .WithMembers(
                     GenerateMembers())
-                .WithGeneratedCodeAttributeOnMembers();
+                .AddGeneratedCodeAttributeOnMembers();
         }
 
         protected virtual TypeParameterListSyntax GenerateTypeParameterList()

--- a/src/Amadevus.RecordGenerator.Generators/PartialGeneratorBase.cs
+++ b/src/Amadevus.RecordGenerator.Generators/PartialGeneratorBase.cs
@@ -2,6 +2,8 @@
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
+using System.Linq;
+using System.Reflection;
 using System.Threading;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 

--- a/src/Amadevus.RecordGenerator.Generators/PartialGeneratorBase.cs
+++ b/src/Amadevus.RecordGenerator.Generators/PartialGeneratorBase.cs
@@ -33,7 +33,8 @@ namespace Amadevus.RecordGenerator.Generators
                 .WithModifiers(
                     GenerateModifiers())
                 .WithMembers(
-                    GenerateMembers());
+                    GenerateMembers())
+                .WithGeneratedCodeAttributeOnMembers();
         }
 
         protected virtual TypeParameterListSyntax GenerateTypeParameterList()

--- a/src/Amadevus.RecordGenerator.Generators/RecordGenerator.cs
+++ b/src/Amadevus.RecordGenerator.Generators/RecordGenerator.cs
@@ -32,7 +32,8 @@ namespace Amadevus.RecordGenerator.Generators
                 {
                     yield break;
                 }
-                yield return RecordPartialGenerator.Generate(descriptor, cancellationToken);
+                yield return RecordPartialGenerator.Generate(descriptor, cancellationToken)
+                    .WithGeneratedCodeAttribute();
                 yield return BuilderPartialGenerator.Generate(descriptor, cancellationToken);
                 yield return DeconstructPartialGenerator.Generate(descriptor, cancellationToken);
                 yield break;

--- a/src/Amadevus.RecordGenerator.Generators/RecordGenerator.cs
+++ b/src/Amadevus.RecordGenerator.Generators/RecordGenerator.cs
@@ -32,8 +32,7 @@ namespace Amadevus.RecordGenerator.Generators
                 {
                     yield break;
                 }
-                yield return RecordPartialGenerator.Generate(descriptor, cancellationToken)
-                    .WithGeneratedCodeAttribute();
+                yield return RecordPartialGenerator.Generate(descriptor, cancellationToken);
                 yield return BuilderPartialGenerator.Generate(descriptor, cancellationToken);
                 yield return DeconstructPartialGenerator.Generate(descriptor, cancellationToken);
                 yield break;

--- a/test/Amadevus.RecordGenerator.Test/GeneratedCodeAttributeGeneratorTests.cs
+++ b/test/Amadevus.RecordGenerator.Test/GeneratedCodeAttributeGeneratorTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
@@ -12,19 +13,78 @@ namespace Amadevus.RecordGenerator.Test
     public class GeneratedCodeAttributeGeneratorTests : RecordTestsBase
     {
         [Fact]
-        public void ReflectedClass_HasGeneratedCodeAttribute()
+        public void ReflectedClass_DoesNotHaveGeneratedCodeAttribute()
         {
             var recordType = typeof(Item);
 
-            var attributeData = recordType.GetCustomAttributesData()
-                .Single(d => d.AttributeType.Equals(typeof(GeneratedCodeAttribute)));
-            var toolName = attributeData.ConstructorArguments.First().Value;
-            var toolVersion = attributeData.ConstructorArguments.Skip(1).First().Value;
+            var result = HasCorrectCodeGeneratedAttribute(recordType.GetCustomAttributesData());
 
-            var expectedName = "Amadevus.RecordGenerator";
-            Assert.Equal(expectedName, toolName);
-            var expectedVersion = GetType().Assembly.GetName().Version.ToString();
-            Assert.Equal(expectedVersion, toolVersion);
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void ReflectedClassMethod_DoesHaveGeneratedCodeAttribute()
+        {
+            var recordType = typeof(Item);
+            var method = recordType.GetMethod(nameof(Item.Update));
+
+            var result = HasCorrectCodeGeneratedAttribute(method.GetCustomAttributesData());
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void ReflectedClassNestedType_DoesNotHaveGeneratedCodeAttribute()
+        {
+            var recordType = typeof(Item);
+            var nestedType = recordType.GetNestedType(nameof(Item.Builder));
+
+            var result = HasCorrectCodeGeneratedAttribute(nestedType.GetCustomAttributesData());
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void ReflectedClassNestedTypeProperty_DoesHaveGeneratedCodeAttribute()
+        {
+            var recordType = typeof(Item);
+            var nestedTypeMethod = recordType.GetNestedType(nameof(Item.Builder))
+                .GetProperty(nameof(Item.Builder.Name));
+
+            var result = HasCorrectCodeGeneratedAttribute(nestedTypeMethod.GetCustomAttributesData());
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void ReflectedClassConstructor_DoesHaveGeneratedCodeAttribute()
+        {
+            var recordType = typeof(Item);
+            var constructor = recordType.GetConstructor(new[] { typeof(string), typeof(string) });
+
+            var result = HasCorrectCodeGeneratedAttribute(constructor.GetCustomAttributesData());
+
+            Assert.True(result);
+        }
+
+        private bool HasCorrectCodeGeneratedAttribute(IList<CustomAttributeData> attributeData)
+        {
+            var codeGeneratedAttributeData = attributeData
+                .Where(d => d.AttributeType.Equals(typeof(GeneratedCodeAttribute)));
+
+            if (!codeGeneratedAttributeData.Any()) return false;
+
+            var codeGeneratedAttribute = codeGeneratedAttributeData.Single();
+
+            var toolName = codeGeneratedAttribute.ConstructorArguments.First().Value;
+            var expectedToolName = "Amadevus.RecordGenerator";
+            if (!toolName.Equals(expectedToolName)) return false;
+
+            var toolVersion = codeGeneratedAttribute.ConstructorArguments.Skip(1).First().Value;
+            var expectedToolVersion = GetType().Assembly.GetName().Version.ToString();
+            if (!toolVersion.Equals(expectedToolVersion)) return false;
+
+            return true;
         }
     }
 }

--- a/test/Amadevus.RecordGenerator.Test/GeneratedCodeAttributeGeneratorTests.cs
+++ b/test/Amadevus.RecordGenerator.Test/GeneratedCodeAttributeGeneratorTests.cs
@@ -1,0 +1,30 @@
+﻿using Amadevus.RecordGenerator.TestsBase;
+using System;
+using System.CodeDom.Compiler;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Amadevus.RecordGenerator.Test
+{
+    public class GeneratedCodeAttributeGeneratorTests : RecordTestsBase
+    {
+        [Fact]
+        public void ReflectedClass_HasGeneratedCodeAttribute()
+        {
+            var recordType = typeof(Item);
+
+            var attributeData = recordType.GetCustomAttributesData()
+                .Single(d => d.AttributeType.Equals(typeof(GeneratedCodeAttribute)));
+            var toolName = attributeData.ConstructorArguments.First().Value;
+            var toolVersion = attributeData.ConstructorArguments.Skip(1).First().Value;
+
+            var expectedName = "Amadevus.RecordGenerator";
+            Assert.Equal(expectedName, toolName);
+            var expectedVersion = GetType().Assembly.GetName().Version.ToString();
+            Assert.Equal(expectedVersion, toolVersion);
+        }
+    }
+}


### PR DESCRIPTION
Add the `GeneratedCodeAttribute` in order to exclude the generated code from code coverage measurements.