### PR TITLE
Generate ToString() for records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+* [`Object.ToString`][objtostr] override for records that follows the same
+  implementation as C# generates for anonymous types
 * `GeneratedCodeAttribute` is added to generated non-type members (methods, properties)
+
+
+[objtostr]: https://docs.microsoft.com/en-us/dotnet/api/system.object.tostring

--- a/src/Amadevus.RecordGenerator.Generators/Names.cs
+++ b/src/Amadevus.RecordGenerator.Generators/Names.cs
@@ -14,6 +14,7 @@
         public const string ToBuilder = "ToBuilder";
         public const string ToImmutable = "ToImmutable";
         public const string Validate = "Validate";
+        public const string ToString = nameof(object.ToString);
 
         public const string ToolName = "Amadevus.RecordGenerator";
         public const string GeneratedCodeAttribute = "System.CodeDom.Compiler.GeneratedCodeAttribute";

--- a/src/Amadevus.RecordGenerator.Generators/Names.cs
+++ b/src/Amadevus.RecordGenerator.Generators/Names.cs
@@ -3,18 +3,18 @@
     internal static class Names
     {
         public const string WithPrefix = "With";
-        
+
         public const string NotSupportedExceptionFull = "System.NotSupportedException";
         public const string Update = "Update";
         public const string UpdateWith = "UpdateWith";
         public const string Deconstruct = "Deconstruct";
-        
+
         public const string Builder = "Builder";
 
         public const string ToBuilder = "ToBuilder";
         public const string ToImmutable = "ToImmutable";
         public const string Validate = "Validate";
-        public const string ToString = nameof(object.ToString);
+        public new const string ToString = nameof(object.ToString);
 
         public const string ToolName = "Amadevus.RecordGenerator";
         public const string GeneratedCodeAttribute = "System.CodeDom.Compiler.GeneratedCodeAttribute";

--- a/src/Amadevus.RecordGenerator.Generators/RecordPartialGenerator.cs
+++ b/src/Amadevus.RecordGenerator.Generators/RecordPartialGenerator.cs
@@ -31,6 +31,7 @@ namespace Amadevus.RecordGenerator.Generators
                     GenerateUpdateMethod())
                 .AddRange(
                     GenerateMutators())
+                .Add(GenerateToString())
                 .Add(GenerateValidatePartialMethod());
         }
 
@@ -128,6 +129,24 @@ namespace Amadevus.RecordGenerator.Generators
             }
         }
 
+        private MemberDeclarationSyntax GenerateToString()
+        {
+            var properties =
+                from e in Descriptor.Entries
+                select AnonymousObjectMemberDeclarator(IdentifierName(e.Identifier));
+            return
+                MethodDeclaration(
+                    PredefinedType(Token(SyntaxKind.StringKeyword)),
+                    Names.ToString)
+                .AddModifiers(SyntaxKind.PublicKeyword, SyntaxKind.OverrideKeyword)
+                .WithExpressionBody(
+                    InvocationExpression(
+                        MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                            AnonymousObjectCreationExpression()
+                                .AddInitializers(properties.ToArray()),
+                            IdentifierName(Names.ToString))));
+        }
+
         private MemberDeclarationSyntax GenerateValidatePartialMethod()
         {
             return
@@ -140,7 +159,7 @@ namespace Amadevus.RecordGenerator.Generators
                 .WithSemicolonToken();
             ParameterSyntax CreateValidateParameter(RecordDescriptor.Entry entry)
             {
-                return 
+                return
                     Parameter(entry.Identifier)
                     .WithType(entry.Type)
                     .AddModifiers(Token(SyntaxKind.RefKeyword));

--- a/test/Amadevus.RecordGenerator.Test/RecordFormatterTests.cs
+++ b/test/Amadevus.RecordGenerator.Test/RecordFormatterTests.cs
@@ -3,6 +3,9 @@ using Xunit;
 
 namespace Amadevus.RecordGenerator.Test
 {
+    using System.Collections.Generic;
+    using TestsBase;
+
     public class RecordFormatterTests : RecordTestsBase
     {
         [Fact]
@@ -31,6 +34,31 @@ namespace Amadevus.RecordGenerator.Test
                 Items = items.ToString(),
             };
             Assert.Equal(shape.ToString(), container.ToString());
+        }
+
+        [Fact]
+        public void With_TreeProperty()
+        {
+            const string foo = nameof(foo);
+            const string bar = nameof(bar);
+
+            var builder = new GenericRecord<string>.Builder
+            {
+                Thing      = foo + bar,
+                Things     = ImmutableArray.Create(foo, bar),
+                RecordTree = ImmutableArray.Create((IReadOnlyList<Item>)ImmutableArray.Create(CreateItem())),
+            };
+
+            var record = builder.ToImmutable();
+
+            var shape = new
+            {
+                record.Thing,
+                record.Things,
+                record.RecordTree,
+            };
+
+            Assert.Equal(shape.ToString(), record.ToString());
         }
     }
 }

--- a/test/Amadevus.RecordGenerator.Test/RecordFormatterTests.cs
+++ b/test/Amadevus.RecordGenerator.Test/RecordFormatterTests.cs
@@ -29,9 +29,9 @@ namespace Amadevus.RecordGenerator.Test
             container.WithItems(items);
             var shape = new
             {
-                Id = ContainerId,
-                Name = ContainerName,
-                Items = items.ToString(),
+                container.Id,
+                container.Name,
+                Items = items,
             };
             Assert.Equal(shape.ToString(), container.ToString());
         }

--- a/test/Amadevus.RecordGenerator.Test/RecordFormatterTests.cs
+++ b/test/Amadevus.RecordGenerator.Test/RecordFormatterTests.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Immutable;
+using Xunit;
+
+namespace Amadevus.RecordGenerator.Test
+{
+    public class RecordFormatterTests : RecordTestsBase
+    {
+        [Fact]
+        public void With_SimpleProperty()
+        {
+            var item = CreateItem();
+            var shape = new
+            {
+                Id = ItemId,
+                Name = ItemName
+            };
+            Assert.Equal(shape.ToString(), item.ToString());
+        }
+
+        [Fact]
+        public void With_CollectionProperty()
+        {
+            var item = CreateItem();
+            var container = CreateContainerEmpty();
+            var items = new[] { item }.ToImmutableArray();
+            container.WithItems(items);
+            var shape = new
+            {
+                Id = ContainerId,
+                Name = ContainerName,
+                Items = items.ToString(),
+            };
+            Assert.Equal(shape.ToString(), container.ToString());
+        }
+    }
+}


### PR DESCRIPTION
This PR adds to #19 by implementing an override for `ToString()`.

The implementation I've added is a quick cheat (that can improved upon) that piggy backs on the built-in implementation of `ToString()` generated by compiler for anonymous types, which is the closest thing we had to records in C# so it seems reasonable to borrow from there. So, say, the generated implementation for the test `Item` will look as follows:

```c#
public override string ToString() => new { Id, Name }.ToString();
```

This gives you:

    { Id = item1, Name = item name }

For `Container`, however, the formatted string becomes:

    { Id = cont1, Name = container name, Items = System.Collections.Immutable.ImmutableArray`1[System.Int32] }

This is not great, but not any different than what you get from anonymous records/types.

The one downside of this implementation is the extra object allocation for the anonymous object but I am hoping that's something one can improve on after feature completion.