### PR TITLE
Align ValidatingRecord.Validate parameter names

### DIFF
--- a/test/Amadevus.RecordGenerator.Test/RecordConstructorTests.cs
+++ b/test/Amadevus.RecordGenerator.Test/RecordConstructorTests.cs
@@ -15,7 +15,7 @@ namespace Amadevus.RecordGenerator.Test
         [Fact]
         public void Ctor_InvokesValidate_Throwing()
         {
-            Assert.Throws<ArgumentNullException>(nameof(ValidatingRecord.Name),() => new ValidatingRecord(null, "a"));
+            Assert.Throws<ArgumentNullException>("name", () => new ValidatingRecord(null, "a"));
         }
 
         [Fact]

--- a/test/Amadevus.RecordGenerator.TestsBase/ValidatingRecord.cs
+++ b/test/Amadevus.RecordGenerator.TestsBase/ValidatingRecord.cs
@@ -14,9 +14,9 @@ namespace Amadevus.RecordGenerator.TestsBase
         /// </summary>
         public string Switch { get; }
 
-        static partial void Validate(ref string Name, ref string Switch)
+        static partial void Validate(ref string name, ref string @switch)
         {
-            if (Name is null) throw new ArgumentNullException(nameof(Name));
+            if (name is null) throw new ArgumentNullException(nameof(name));
         }
     }
 }


### PR DESCRIPTION
The generation partial declaration of `ValidatingRecord.Validate` had parameters in camel-case whereas the definition's parameters were still in Pascal-case. This PR aligns the two.