### PR TITLE
💡 Make validation method post-init & parameter-less

### DIFF
--- a/src/Amadevus.RecordGenerator.Generators/Names.cs
+++ b/src/Amadevus.RecordGenerator.Generators/Names.cs
@@ -13,7 +13,7 @@
 
         public const string ToBuilder = "ToBuilder";
         public const string ToImmutable = "ToImmutable";
-        public const string Validate = "Validate";
+        public const string OnConstructed = nameof(OnConstructed);
         public new const string ToString = nameof(object.ToString);
 
         public const string Value = "value";

--- a/src/Amadevus.RecordGenerator.Generators/RecordPartialGenerator.cs
+++ b/src/Amadevus.RecordGenerator.Generators/RecordPartialGenerator.cs
@@ -28,11 +28,11 @@ namespace Amadevus.RecordGenerator.Generators
                 PartialGenerator.Member(Features.ToString, GenerateToString));
 
         private static readonly MethodDeclarationSyntax PartialValidateMethodDeclaration =
-                MethodDeclaration(
-                    PredefinedType(Token(SyntaxKind.VoidKeyword)),
-                    Names.Validate)
-                .AddModifiers(SyntaxKind.PartialKeyword)
-                .WithSemicolonToken();
+            MethodDeclaration(
+                PredefinedType(Token(SyntaxKind.VoidKeyword)),
+                Names.Validate)
+            .AddModifiers(SyntaxKind.PartialKeyword)
+            .WithSemicolonToken();
 
         private static readonly StatementSyntax ValidateInvocationStatement =
             ExpressionStatement(InvocationExpression(IdentifierName(PartialValidateMethodDeclaration.Identifier)));

--- a/src/Amadevus.RecordGenerator.Generators/RecordPartialGenerator.cs
+++ b/src/Amadevus.RecordGenerator.Generators/RecordPartialGenerator.cs
@@ -17,7 +17,7 @@ namespace Amadevus.RecordGenerator.Generators
                         PartialGenerationResult.Empty
                         .AddMembers(
                             GenerateConstructor(descriptor),
-                            PartialValidateMethodDeclaration)),
+                            PartialOnConstructedMethodDeclaration)),
                 // withers
                 PartialGenerator.Create(Features.Withers,
                     descriptor =>
@@ -27,15 +27,15 @@ namespace Amadevus.RecordGenerator.Generators
                 // string formatting
                 PartialGenerator.Member(Features.ToString, GenerateToString));
 
-        private static readonly MethodDeclarationSyntax PartialValidateMethodDeclaration =
+        private static readonly MethodDeclarationSyntax PartialOnConstructedMethodDeclaration =
             MethodDeclaration(
                 PredefinedType(Token(SyntaxKind.VoidKeyword)),
-                Names.Validate)
+                Names.OnConstructed)
             .AddModifiers(SyntaxKind.PartialKeyword)
             .WithSemicolonToken();
 
-        private static readonly StatementSyntax ValidateInvocationStatement =
-            ExpressionStatement(InvocationExpression(IdentifierName(PartialValidateMethodDeclaration.Identifier)));
+        private static readonly StatementSyntax OnConstructedInvocationStatement =
+            ExpressionStatement(InvocationExpression(IdentifierName(PartialOnConstructedMethodDeclaration.Identifier)));
 
         private static ConstructorDeclarationSyntax GenerateConstructor(RecordDescriptor descriptor)
         {
@@ -47,7 +47,7 @@ namespace Amadevus.RecordGenerator.Generators
                 .WithBodyStatements(
                     descriptor.Entries
                     .Select(CreateCtorAssignment)
-                    .Append(ValidateInvocationStatement));
+                    .Append(OnConstructedInvocationStatement));
             StatementSyntax CreateCtorAssignment(RecordDescriptor.Entry entry)
             {
                 return

--- a/test/Amadevus.RecordGenerator.Test/RecordConstructorTests.cs
+++ b/test/Amadevus.RecordGenerator.Test/RecordConstructorTests.cs
@@ -13,13 +13,13 @@ namespace Amadevus.RecordGenerator.Test
         }
 
         [Fact]
-        public void Ctor_InvokesValidate_Throwing()
+        public void Ctor_InvokesOnConstructed_Throwing()
         {
-            Assert.Throws<ArgumentNullException>("name", () => new ValidatingRecord(null, "a"));
+            Assert.Throws<ArgumentNullException>(nameof(Item.Name), () => new ValidatingRecord(null, "a"));
         }
 
         [Fact]
-        public void Ctor_InvokesValidate_Passing()
+        public void Ctor_InvokesOnConstructed_Passing()
         {
             Assert.NotNull(new ValidatingRecord(ItemName, "test"));
         }

--- a/test/Amadevus.RecordGenerator.Test/RecordMutatorTests.cs
+++ b/test/Amadevus.RecordGenerator.Test/RecordMutatorTests.cs
@@ -29,7 +29,7 @@ namespace Amadevus.RecordGenerator.Test
         }
 
         [Fact]
-        public void Ctor_InvokesValidate_Throwing()
+        public void With_InvokesValidate_Throwing()
         {
             var item = CreateItem();
             //

--- a/test/Amadevus.RecordGenerator.Test/RecordMutatorTests.cs
+++ b/test/Amadevus.RecordGenerator.Test/RecordMutatorTests.cs
@@ -32,7 +32,14 @@ namespace Amadevus.RecordGenerator.Test
         public void Ctor_InvokesValidate_Throwing()
         {
             var item = CreateItem();
-            Assert.Throws<ArgumentNullException>("value", () => item.WithName(null));
+            //
+            // NOTE! We test that validation is indeed invoked but don't
+            // test the parameter name since it comes from the validation
+            // method that assumes the name of the corresponding parameter on
+            // the constructor ("name") as opposed to WithName (the parameter
+            // of all with-methods is always named "value").
+            //
+            Assert.Throws<ArgumentNullException>(() => item.WithName(null));
         }
 
         [Fact]

--- a/test/Amadevus.RecordGenerator.Test/RecordMutatorTests.cs
+++ b/test/Amadevus.RecordGenerator.Test/RecordMutatorTests.cs
@@ -29,7 +29,7 @@ namespace Amadevus.RecordGenerator.Test
         }
 
         [Fact]
-        public void Ctor_InvokesValidate_Passing()
+        public void Ctor_InvokesValidate_Throwing()
         {
             var item = CreateItem();
             Assert.Throws<ArgumentNullException>("value", () => item.WithName(null));

--- a/test/Amadevus.RecordGenerator.Test/RecordMutatorTests.cs
+++ b/test/Amadevus.RecordGenerator.Test/RecordMutatorTests.cs
@@ -1,4 +1,5 @@
-﻿using Amadevus.RecordGenerator.TestsBase;
+﻿using System;
+using Amadevus.RecordGenerator.TestsBase;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Text;
@@ -25,6 +26,13 @@ namespace Amadevus.RecordGenerator.Test
             var item = CreateItem();
             var modifiedItem = item.WithName(newName);
             Assert.Equal(newName, modifiedItem.Name);
+        }
+
+        [Fact]
+        public void Ctor_InvokesValidate_Passing()
+        {
+            var item = CreateItem();
+            Assert.Throws<ArgumentNullException>("value", () => item.WithName(null));
         }
 
         [Fact]

--- a/test/Amadevus.RecordGenerator.Test/RecordMutatorTests.cs
+++ b/test/Amadevus.RecordGenerator.Test/RecordMutatorTests.cs
@@ -29,17 +29,10 @@ namespace Amadevus.RecordGenerator.Test
         }
 
         [Fact]
-        public void With_InvokesValidate_Throwing()
+        public void With_InvokesOnConstructed_Throwing()
         {
             var item = CreateItem();
-            //
-            // NOTE! We test that validation is indeed invoked but don't
-            // test the parameter name since it comes from the validation
-            // method that assumes the name of the corresponding parameter on
-            // the constructor ("name") as opposed to WithName (the parameter
-            // of all with-methods is always named "value").
-            //
-            Assert.Throws<ArgumentNullException>(() => item.WithName(null));
+            Assert.Throws<ArgumentNullException>(nameof(Item.Name), () => item.WithName(null));
         }
 
         [Fact]

--- a/test/Amadevus.RecordGenerator.TestsBase/FeaturesTestType.cs
+++ b/test/Amadevus.RecordGenerator.TestsBase/FeaturesTestType.cs
@@ -11,9 +11,9 @@
             // and we won't see it in reflection anyway.
             // But since we have to implement it, it's already testing
             // that the generated partial declaration exists during compilation.
-            static partial void Validate(ref string name)
+            partial void Validate()
             {
-                if (name is null) throw new System.ArgumentNullException(nameof(name));
+                if (Name is null) throw new System.ArgumentNullException("name");
             }
         }
 

--- a/test/Amadevus.RecordGenerator.TestsBase/FeaturesTestType.cs
+++ b/test/Amadevus.RecordGenerator.TestsBase/FeaturesTestType.cs
@@ -11,7 +11,7 @@
             // and we won't see it in reflection anyway.
             // But since we have to implement it, it's already testing
             // that the generated partial declaration exists during compilation.
-            partial void Validate()
+            partial void OnConstructed()
             {
                 if (Name is null) throw new System.ArgumentNullException("name");
             }

--- a/test/Amadevus.RecordGenerator.TestsBase/FeaturesTestType.cs
+++ b/test/Amadevus.RecordGenerator.TestsBase/FeaturesTestType.cs
@@ -13,7 +13,7 @@
             // that the generated partial declaration exists during compilation.
             partial void OnConstructed()
             {
-                if (Name is null) throw new System.ArgumentNullException("name");
+                if (Name is null) throw new System.ArgumentNullException(nameof(Name));
             }
         }
 

--- a/test/Amadevus.RecordGenerator.TestsBase/Item.cs
+++ b/test/Amadevus.RecordGenerator.TestsBase/Item.cs
@@ -25,7 +25,7 @@ namespace Amadevus.RecordGenerator.TestsBase
 
         partial void OnConstructed()
         {
-            if (Name is null) throw new ArgumentNullException("name");
+            if (Name is null) throw new ArgumentNullException(nameof(Name));
         }
     }
 }

--- a/test/Amadevus.RecordGenerator.TestsBase/Item.cs
+++ b/test/Amadevus.RecordGenerator.TestsBase/Item.cs
@@ -23,7 +23,7 @@ namespace Amadevus.RecordGenerator.TestsBase
             get { return Id + Name; }
         }
 
-        partial void Validate()
+        partial void OnConstructed()
         {
             if (Name is null) throw new ArgumentNullException("name");
         }

--- a/test/Amadevus.RecordGenerator.TestsBase/Item.cs
+++ b/test/Amadevus.RecordGenerator.TestsBase/Item.cs
@@ -1,4 +1,6 @@
-﻿namespace Amadevus.RecordGenerator.TestsBase
+﻿using System;
+
+namespace Amadevus.RecordGenerator.TestsBase
 {
     [Record]
     public partial class Item
@@ -19,6 +21,11 @@
         public string CalculatedAccessorBlockBody
         {
             get { return Id + Name; }
+        }
+
+        partial void Validate()
+        {
+            if (Name is null) throw new ArgumentNullException("name");
         }
     }
 }

--- a/test/Amadevus.RecordGenerator.TestsBase/ValidatingRecord.cs
+++ b/test/Amadevus.RecordGenerator.TestsBase/ValidatingRecord.cs
@@ -16,7 +16,7 @@ namespace Amadevus.RecordGenerator.TestsBase
 
         partial void OnConstructed()
         {
-            if (Name == null) throw new ArgumentNullException("name");
+            if (Name is null) throw new ArgumentNullException(nameof(Name));
         }
     }
 }

--- a/test/Amadevus.RecordGenerator.TestsBase/ValidatingRecord.cs
+++ b/test/Amadevus.RecordGenerator.TestsBase/ValidatingRecord.cs
@@ -14,9 +14,9 @@ namespace Amadevus.RecordGenerator.TestsBase
         /// </summary>
         public string Switch { get; }
 
-        static partial void Validate(ref string name, ref string @switch)
+        partial void Validate()
         {
-            if (name is null) throw new ArgumentNullException(nameof(name));
+            if (Name is null) throw new ArgumentNullException("name");
         }
     }
 }

--- a/test/Amadevus.RecordGenerator.TestsBase/ValidatingRecord.cs
+++ b/test/Amadevus.RecordGenerator.TestsBase/ValidatingRecord.cs
@@ -14,12 +14,9 @@ namespace Amadevus.RecordGenerator.TestsBase
         /// </summary>
         public string Switch { get; }
 
-        partial void Validate() =>
-            Validate(Name);
-
-        static void Validate(string name)
+        partial void OnConstructed()
         {
-            if (name == null) throw new ArgumentNullException(nameof(name));
+            if (Name == null) throw new ArgumentNullException("name");
         }
     }
 }

--- a/test/Amadevus.RecordGenerator.TestsBase/ValidatingRecord.cs
+++ b/test/Amadevus.RecordGenerator.TestsBase/ValidatingRecord.cs
@@ -14,9 +14,12 @@ namespace Amadevus.RecordGenerator.TestsBase
         /// </summary>
         public string Switch { get; }
 
-        partial void Validate()
+        partial void Validate() =>
+            Validate(Name);
+
+        static void Validate(string name)
         {
-            if (Name is null) throw new ArgumentNullException("name");
+            if (name == null) throw new ArgumentNullException(nameof(name));
         }
     }
 }


### PR DESCRIPTION
This PR demonstrates the idea discussed in [my comment](https://github.com/amis92/RecordGenerator/issues/54#issuecomment-519404007) to #54.

One side benefit of a parameter-less `Validate` method is that the syntax trees for the declaration and invocation can be shared singletons.

One new downside I discovered while taking the idea for a spin is that argument names are lost and so you have to quote and sync them manually instead of being able to rely on `nameof`. 😢 

If you like & agree with the idea, then feel free to merge the PR. Otherwise I consider it to be a demonstration/spike PR that can be closed if we conclude that this doesn't cut it.
