### PR TITLE
Struct support

### DIFF
--- a/Amadevus.RecordGenerator.sln
+++ b/Amadevus.RecordGenerator.sln
@@ -26,6 +26,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
 		appveyor.yml = appveyor.yml
+		CHANGELOG.md = CHANGELOG.md
 		Directory.Build.props = Directory.Build.props
 		global.json = global.json
 		LICENSE = LICENSE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* `struct` definitions now supported
 * [`Object.ToString`][objtostr] override for records that follows the same
   implementation as C# generates for anonymous types
 * `GeneratedCodeAttribute` is added to generated non-type members (methods, properties)

--- a/src/Amadevus.RecordGenerator.Attributes/RecordAttribute.cs
+++ b/src/Amadevus.RecordGenerator.Attributes/RecordAttribute.cs
@@ -7,7 +7,7 @@ namespace Amadevus.RecordGenerator
     /// <summary>
     /// This attribute triggers record code generation. <see href="https://amis92.github.io/RecordGenerator/"/>
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false, AllowMultiple = false)]
     [CodeGenerationAttribute("Amadevus.RecordGenerator.Generators.RecordGenerator, Amadevus.RecordGenerator.Generators")]
     [Conditional("CodeGeneration")]
     public sealed class RecordAttribute : Attribute

--- a/src/Amadevus.RecordGenerator.Generators/EqualityGenerators.cs
+++ b/src/Amadevus.RecordGenerator.Generators/EqualityGenerators.cs
@@ -133,21 +133,26 @@ namespace Amadevus.RecordGenerator.Generators
 
         private static BlockSyntax GenerateForwardToEquatableEquals(RecordDescriptor descriptor)
         {
-            // return this.Equals(obj as MyRecord);
+            // return obj is MyRecord castObj && this.Equals(castObj);
+            const string otherVariableName = "other";
             return
                 Block(
                     ReturnStatement(
+                        BinaryExpression(
+                            LogicalAndExpression,
+                            IsPatternExpression(
+                                IdentifierName(objVariableName),
+                                DeclarationPattern(
+                                    descriptor.TypeSyntax,
+                                    SingleVariableDesignation(Identifier(otherVariableName)))),
                         InvocationExpression(
                             MemberAccessExpression(
                                 SimpleMemberAccessExpression,
                                 ThisExpression(),
-                                IdentifierName(EqualsMethodName)))
-                        .AddArgumentListArguments(
-                            Argument(
-                                BinaryExpression(
-                                    AsExpression,
-                                    IdentifierName(objVariableName),
-                                    descriptor.TypeSyntax)))));
+                                IdentifierName(EqualsMethodName))
+                        ).WithArgumentList(ArgumentList(
+                            SingletonSeparatedList(
+                                Argument(IdentifierName(otherVariableName))))))));
         }
 
         private static MemberDeclarationSyntax GenerateGetHashCode(RecordDescriptor descriptor)

--- a/src/Amadevus.RecordGenerator.Generators/EqualityGenerators.cs
+++ b/src/Amadevus.RecordGenerator.Generators/EqualityGenerators.cs
@@ -133,7 +133,7 @@ namespace Amadevus.RecordGenerator.Generators
 
         private static BlockSyntax GenerateForwardToEquatableEquals(RecordDescriptor descriptor)
         {
-            // return obj is MyRecord castObj && this.Equals(castObj);
+            // return obj is MyRecord other && this.Equals(other);
             const string otherVariableName = "other";
             return
                 Block(
@@ -174,7 +174,7 @@ namespace Amadevus.RecordGenerator.Generators
                     PublicKeyword,
                     OverrideKeyword)
                 .AddBodyStatements(statement);
-            
+
             StatementSyntax SinglePropertyGetHashCode()
             {
                 // public override int GetHashCode() {

--- a/src/Amadevus.RecordGenerator.Generators/RecordDescriptorExtensions.cs
+++ b/src/Amadevus.RecordGenerator.Generators/RecordDescriptorExtensions.cs
@@ -21,7 +21,7 @@ namespace Amadevus.RecordGenerator.Generators
                 symbol.GetQualifiedName());
         }
 
-        public static RecordDescriptor ToRecordDescriptor(this ClassDeclarationSyntax typeDeclaration, SemanticModel semanticModel)
+        public static RecordDescriptor ToRecordDescriptor(this TypeDeclarationSyntax typeDeclaration, SemanticModel semanticModel)
         {
             return new RecordDescriptor(
                 typeDeclaration.GetTypeSyntax().WithoutTrivia(),

--- a/src/Amadevus.RecordGenerator.Generators/RecordGenerator.cs
+++ b/src/Amadevus.RecordGenerator.Generators/RecordGenerator.cs
@@ -34,10 +34,11 @@ namespace Amadevus.RecordGenerator.Generators
 
         public Task<SyntaxList<MemberDeclarationSyntax>> GenerateAsync(TransformationContext context, IProgress<Diagnostic> progress, CancellationToken cancellationToken)
         {
-            // Support Class + Structs.
-            return context.ProcessingNode is TypeDeclarationSyntax tds && (tds.Kind() == SyntaxKind.ClassDeclaration || tds.Kind() == SyntaxKind.StructDeclaration)
-                ? GenerateAsync(tds)
-                : EmptyResultTask;
+            return
+                context.ProcessingNode is TypeDeclarationSyntax tds
+                && (tds.IsKind(SyntaxKind.ClassDeclaration) || tds.IsKind(SyntaxKind.StructDeclaration))
+                    ? GenerateAsync(tds)
+                    : EmptyResultTask;
 
             Task<SyntaxList<MemberDeclarationSyntax>> GenerateAsync(TypeDeclarationSyntax typeDeclaration)
             {
@@ -49,8 +50,8 @@ namespace Amadevus.RecordGenerator.Generators
                 var features = GetFeatures();
                 var partialKeyword = Token(SyntaxKind.PartialKeyword);
 
-                var declaration = typeDeclaration.Kind() == SyntaxKind.ClassDeclaration 
-                        ? (TypeDeclarationSyntax)ClassDeclaration(descriptor.TypeIdentifier) 
+                var declaration = typeDeclaration.Kind() == SyntaxKind.ClassDeclaration
+                        ? (TypeDeclarationSyntax)ClassDeclaration(descriptor.TypeIdentifier)
                         : (TypeDeclarationSyntax)StructDeclaration(descriptor.TypeIdentifier);
 
                 var declarationWithTypeList = declaration.WithTypeParameterList(typeDeclaration.TypeParameterList?.WithoutTrivia());
@@ -70,7 +71,7 @@ namespace Amadevus.RecordGenerator.Generators
                               .WithModifiers(
                                   TokenList(
                                       g.Modifiers
-                                      .Except(new[] {partialKeyword})
+                                      .Except(new[] { partialKeyword })
                                       .Append(partialKeyword)))
                               .WithMembers(List(g.Members))
                               .AddGeneratedCodeAttributeOnMembers(),

--- a/test/Amadevus.RecordGenerator.TestsBase/StructContainer.cs
+++ b/test/Amadevus.RecordGenerator.TestsBase/StructContainer.cs
@@ -1,0 +1,8 @@
+﻿namespace Amadevus.RecordGenerator.TestsBase
+{
+    [Record(Features.Default | Features.Equality)]
+    public readonly partial struct StructContainer 
+    {
+        public int Id { get; }
+    }
+}


### PR DESCRIPTION
We have just started using this project to generate our Record types - it works nicely but we often have single property records that are best suited to be structs.  It's a fairly simple job to do this and I have also improved some of the generator code to optimize around the "single property" case.

More or less solves #79 

Please let me know if you'd like to see more of anything, it was a fairly quick job to get this far.  I couldn't work out the cleanest way to choose/override the `Features` property so ended up just declaring a `Features.StructRecommended` entry.  I have tested this with `readonly struct` types too and it all works nicely.