### PR TITLE
fix: remove NuGet MinClientVersion since it doesn't help much

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,7 +24,6 @@
     <PackageOutputPath>$(MSBuildThisFileDirectory)bin/Packages/$(Configuration)/</PackageOutputPath>
     <IsTestingOnlyProject>$(MSBuildProjectName.Contains('Test'))</IsTestingOnlyProject>
     <NoWarn>$(NoWarn);CS1591;NU5105</NoWarn>
-    <MinClientVersion>4.3.0</MinClientVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" !$(IsTestingOnlyProject) ">


### PR DESCRIPTION
For *a* reason NuGet.org gallery doesn't allow 4.3 MinClientVersion.

See https://dev.azure.com/amadevus/RecordGenerator/_releaseProgress?_a=release-environment-logs&releaseId=4&environmentId=5

![image](https://user-images.githubusercontent.com/2671396/64038659-e91c0900-cb58-11e9-9591-060500f713d7.png)
