### PR TITLE
chore: update Nerdbank.GitVersioning to v3.0.25

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -29,7 +29,7 @@
                             Version="1.0.0-beta2-19367-01"
                             Condition=" !$(IsTestingOnlyProject) " />
     <GlobalPackageReference Include="Nerdbank.GitVersioning"
-                            Version="2.3.183" />
+                            Version="3.0.25" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
fixes issue with semver2 prerelease versions